### PR TITLE
Update MetabaseHttpPlugin.go

### DIFF
--- a/MetabaseHttpPlugin.go
+++ b/MetabaseHttpPlugin.go
@@ -31,16 +31,25 @@ func (MetabaseHttpPlugin) GetStage() string {
 }
 func (plugin MetabaseHttpPlugin) Verify(request l9format.WebPluginRequest, response l9format.WebPluginResponse, event *l9format.L9Event, options map[string]string) (hasLeak bool) {
 	// if not checking for request , or not 200 or html, quit
-	if !request.EqualAny(plugin.GetRequests()) || response.Response.StatusCode != 200 || response.Document != nil {
+	if !request.EqualAny(plugin.GetRequests()) || response.Response.StatusCode != 200 {
 		return false
 	}
-	if strings.Contains(string(response.Body), "localhost") {
-		event.Leak.Type = "lfi"
-		event.Leak.Severity = "critical"
-		event.AddTag("CVE-2021-41277")
-		event.Summary = "Found /etc/hosts through CVE-2021-41277:\n" + string(response.Body)
-		return true
+	lowerBody := strings.ToLower(string(response.Body))
+	if len(lowerBody) < 10 {
+		return false
 	}
-	return false
+	if strings.Contains(lowerBody, "<html") {
+		return false
+	}
+	if !strings.Contains(lowerBody, "localhost") && !strings.Contains(lowerBody, "127") {
+		return false
+	}
+	event.Service.Software.Name = "Metabase"
+	event.Leak.Type = "lfi"
+	event.Leak.Severity = "critical"
+	event.AddTag("cve-2021-41277")
+	event.Summary = "Found /etc/hosts through CVE-2021-41277:\n" + string(response.Body)
+	return true
+
 }
 


### PR DESCRIPTION
- Document not reliable to detect non-html content, using `<html`
- Added few more checks